### PR TITLE
feat(sensors): add PMSA003I particulate matter sensor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ dependencies = [
  "futures",
  "heapless",
  "log",
+ "pmsa003i",
  "sensor-scd30",
  "serde",
  "serde_json",
@@ -1297,6 +1298,13 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pmsa003i"
+version = "0.1.0"
+dependencies = [
+ "embedded-hal 0.2.7",
+]
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a21b9440a626c7fc8573a9e3d3a06b75c7c97754c2949bc7857b90353ca655"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,15 +46,24 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-task"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "atomic-polyfill"
@@ -49,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
+checksum = "c314e70d181aa6053b26e3f7fbf86d1dfff84f816a6175b967666b3506ef7289"
 dependencies = [
  "critical-section",
 ]
@@ -92,7 +119,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 1.0.109",
  "which",
 ]
 
@@ -121,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
+checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr",
  "serde",
@@ -131,22 +158,22 @@ dependencies = [
 
 [[package]]
 name = "build-time"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b516fccffbcd4c007256d0d620522ea9fcc6f008c9ebb7173eeb349dfcf99786"
+checksum = "f1219c19fc29b7bfd74b7968b420aff5bc951cf517800176e795d6b2300dd382"
 dependencies = [
  "chrono",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -156,9 +183,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "camino"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6031a462f977dd38968b6f23378356512feeace69cef817e1a4475108093cec3"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
@@ -174,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -188,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.12.4"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a621d5d6d6c8d086dbaf1fe659981da41a1b63c6bdbba30b4dbb592c6d3bd49"
+checksum = "7f83bc2e401ed041b7057345ebc488c005efa0341d5541ce7004d30458d0090b"
 dependencies = [
  "serde",
  "toml",
@@ -236,24 +263,21 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "clang-sys"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
@@ -262,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
@@ -274,16 +298,6 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
 
 [[package]]
 name = "const_format"
@@ -307,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "crc32fast"
@@ -325,40 +339,6 @@ name = "critical-section"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
 
 [[package]]
 name = "crossbeam-queue"
@@ -380,54 +360,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.91"
+name = "cvt"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "d2ae9bf77fbf2d39ef573205d554d87e86c12f1994e9ea335b0651b9b278bcf1"
 dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "cfg-if",
 ]
 
 [[package]]
 name = "darling"
-version = "0.14.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -435,33 +380,33 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "defmt"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a0ae7494d9bff013d7b89471f4c424356a71e9752e0c78abe7e6c608a16bb3"
+checksum = "956673bd3cb347512bf988d1e8d89ac9a82b64f6eec54d3c01c3529dac019882"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -469,41 +414,24 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8500cbe4cca056412efce4215a63d0bc20492942aeee695f23b624a53e0a6854"
+checksum = "b4abc4821bd84d3d8f49945ddb24d029be9385ed9b77c99bf2f6296847a6a9f0"
 dependencies = [
  "defmt-parser",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "defmt-parser"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db23d29972d99baa3de2ee2ae3f104c10564a6d05a346eb3f4c4f2c0525a06e"
-
-[[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "269924c02afd7f94bc4cecbfa5c379f6ffcf9766b3408fe63d22c728654eccd0"
 dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+ "thiserror",
 ]
 
 [[package]]
@@ -572,14 +500,13 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c0c57d163dba8ff55a874966d9a1ae755859028308833923a1edeec1a6c215"
+checksum = "cd403e218939bba4a1fe4b58c6f81bf0818852bdd824147f95e6dc4ff4166ac4"
 dependencies = [
- "atomic-polyfill 1.0.1",
+ "atomic-polyfill 1.0.2",
  "cfg-if",
  "critical-section",
- "embassy-sync",
  "embedded-hal 0.2.7",
  "futures-util",
  "heapless",
@@ -591,7 +518,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
 dependencies = [
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
@@ -651,18 +578,18 @@ dependencies = [
 
 [[package]]
 name = "embuild"
-version = "0.31.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65388407a519276cd9aa94291380649d4cedbe8cf566d40f436f7a1ea9b5f8fe"
+checksum = "3ad838e9b86748e477f1d882c41777978947ca3a1f0cdde572234bc7dc68ed3d"
 dependencies = [
  "anyhow",
  "bindgen",
  "bitflags",
  "cargo_toml",
  "cmake",
- "dirs",
  "filetime",
  "globwalk",
+ "home",
  "log",
  "remove_dir_all",
  "serde",
@@ -678,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.0.12"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19be8061a06ab6f3a6cf21106c873578bf01bd42ad15e0311a9c76161cb1c753"
+checksum = "e875f1719c16de097dee81ed675e2d9bb63096823ed3f0ca827b7dea3028bbbb"
 dependencies = [
  "enumset_derive",
  "serde",
@@ -688,14 +615,14 @@ dependencies = [
 
 [[package]]
 name = "enumset_derive"
-version = "0.6.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
+checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -709,13 +636,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -747,7 +674,7 @@ dependencies = [
  "enumset",
  "esp-idf-sys",
  "heapless",
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
@@ -800,21 +727,21 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
- "windows-sys 0.45.0",
+ "redox_syscall 0.2.16",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -836,10 +763,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.26"
+name = "fs_at"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "0504bab20f4487fdf1c20ed48e3e32c7951827a778cd3dfded1768f90b6abb0a"
+dependencies = [
+ "aligned",
+ "cfg-if",
+ "cvt",
+ "libc",
+ "nix",
+ "smart-default",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -852,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -862,15 +804,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -879,38 +821,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -925,17 +867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,7 +878,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "bstr",
  "fnv",
  "log",
@@ -990,7 +921,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.5",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -1011,35 +942,40 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -1077,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1096,12 +1032,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
+ "hermit-abi",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1112,9 +1049,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1133,9 +1070,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -1148,19 +1085,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -1188,15 +1116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,9 +1123,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -1217,14 +1136,26 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
 dependencies = [
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
 name = "nb"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
 
 [[package]]
 name = "no-std-net"
@@ -1243,6 +1174,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1265,16 +1205,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,7 +1222,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1319,7 +1249,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -1338,22 +1268,22 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1370,9 +1300,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
-version = "1.0.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c00c8683a03bd4fe7db7dd64ab4abee6b42166bc81231da983486ce96be51a"
+checksum = "dc59d1bcc64fc5d021d67521f818db868368028108d37f0e98d74e33f68297b5"
 dependencies = [
  "serde",
 ]
@@ -1406,7 +1336,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -1423,42 +1353,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -1471,44 +1379,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
+name = "redox_syscall"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.1",
  "memchr",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
+checksum = "23895cfadc1917fed9c6ed76a8c2903615fa3704f7493ff82b364c6540acc02b"
 dependencies = [
+ "aligned",
+ "cfg-if",
+ "cvt",
+ "fs_at",
+ "lazy_static",
  "libc",
- "log",
- "num_cpus",
- "rayon",
- "winapi",
+ "normpath",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1543,16 +1452,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1569,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
@@ -1595,12 +1504,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5e082f6ea090deaf0e6dd04b68360fd5cddb152af6ce8927c9d25db299f98c"
-
-[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
@@ -1631,32 +1534,41 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+dependencies = [
  "serde",
 ]
 
@@ -1705,6 +1617,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,9 +1635,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
@@ -1724,6 +1647,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"
@@ -1753,7 +1682,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1766,7 +1695,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1781,32 +1710,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.4.0"
+name = "syn"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
+name = "tempfile"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
- "winapi-util",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "thingbuf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2d290fe0db0225026350bc1f0bd02b2daad43b09b56780e29e549effcd54a"
+checksum = "4706f1bfb859af03f099ada2de3cea3e515843c2d3e93b7893f16d94a37f9415"
 dependencies = [
  "parking_lot",
  "pin-project",
@@ -1814,22 +1745,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1843,20 +1774,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tinymetrics"
 version = "0.1.0"
-source = "git+https://github.com/hawkw/tinymetrics#a5dce67b8efbbf762c11f0a3e75b26418a2866d2"
+source = "git+https://github.com/hawkw/tinymetrics#825d2058176bc15612275e10ecddf11c32d8821f"
 dependencies = [
  "portable-atomic",
  "serde",
@@ -1879,50 +1799,58 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
-
-[[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "uncased"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
 dependencies = [
  "version_check",
 ]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775c11906edafc97bc378816b94585fbd9a054eabaf86fdd0ced94af449efab7"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -1938,12 +1866,6 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -2004,32 +1926,19 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
 [[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2037,24 +1946,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2062,28 +1971,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2151,18 +2060,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.42.0"
+name = "windows"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2171,71 +2074,137 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.3.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,15 @@
+[workspace]
+members = [
+    ".",
+    "pmsa003i",
+]
+resolver = "2"
+
 [package]
 name = "eclss"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2021"
-resolver = "2"
-
 
 [profile.release]
 opt-level = "z"
@@ -65,6 +70,7 @@ tinymetrics = { git = "https://github.com/hawkw/tinymetrics", default-features =
     "serde",
     "std",
 ]}
+pmsa003i = { path = "pmsa003i" }
 
 [build-dependencies]
 embuild = "0.31.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,8 +34,8 @@ format][prom].
   + **[Bosch BME680][bme680] temperature, barometric pressure, humidity, and
     VOC** (MOX gas sensor). i meant to get the slightly newer BME688 breakout
     but i clicked the wrong one. a BME688 would also work.
-  + **[Plantower PMSA003I][pmsa003i] particulate matter sensor** (PLANNED). i
-    haven't actually bought this one yet.
+  + **[Plantower PMSA003I][pmsa003i] particulate matter sensor**, measuring
+    particulate matter concetrations.
   + **more sensors coming soon!** there are several different I<sup>2</sup>C
     air quality sensors, and even more different temperature/pressure/humidity
     sensors, on the market. eventually, i'd like to add drivers for most of the
@@ -81,7 +81,7 @@ format][prom].
   display ECLSS prometheus metrics:
 
   ![grafana screenshot](assets/grafana.png)
-  
+
 [prom]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 [`msiebuhr/prometheus-mdns-sd`]: https://github.com/msiebuhr/prometheus-mdns-sd
 

--- a/pmsa003i/Cargo.toml
+++ b/pmsa003i/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "pmsa003i"
+version = "0.1.0"
+authors = ["Eliza Weisman <eliza@elizas.website>"]
+edition = "2021"
+
+[dependencies]
+embedded-hal = { version = "0.2.5" }

--- a/pmsa003i/Cargo.toml
+++ b/pmsa003i/Cargo.toml
@@ -3,6 +3,8 @@ name = "pmsa003i"
 version = "0.1.0"
 authors = ["Eliza Weisman <eliza@elizas.website>"]
 edition = "2021"
+readme = "README.md"
+license = "MIT"
 
 [dependencies]
 embedded-hal = { version = "0.2.5" }

--- a/pmsa003i/README.md
+++ b/pmsa003i/README.md
@@ -1,0 +1,8 @@
+# pmsa003i
+
+An [`embedded-hal`] driver for the PMSA003I I²C particulate matter sensor
+from Plantower.
+
+See also the [datasheet] for this part, which is extremely...translated.
+
+[datasheet]: https://cdn-shop.adafruit.com/product-files/4632/4505_PMSA003I_series_data_manual_English_V2.6.pdf

--- a/pmsa003i/src/lib.rs
+++ b/pmsa003i/src/lib.rs
@@ -1,8 +1,4 @@
-// stolen from
-// https://github.com/adafruit/Adafruit_PM25AQI/blob/master/Adafruit_PM25AQI.cpp
-// except the bugs, which are my own :)
-// and also the datasheet, which is extremely translated:
-// https://cdn-shop.adafruit.com/product-files/4632/4505_PMSA003I_series_data_manual_English_V2.6.pdf
+#![doc = include_str!("../README.md")]
 use core::fmt;
 use embedded_hal::blocking::i2c;
 

--- a/pmsa003i/src/lib.rs
+++ b/pmsa003i/src/lib.rs
@@ -90,6 +90,13 @@ const MAGIC: u16 = 0x424d;
 const PACKET_LEN: usize = 32;
 const I2C_ADDR: u8 = 0x12;
 
+impl<I> Pmsa003i<I> {
+    #[must_use]
+    pub const fn new(i2c: I) -> Self {
+        Self { i2c }
+    }
+}
+
 impl<I, E> Pmsa003i<I>
 where
     I: i2c::Read<Error = E>,

--- a/pmsa003i/src/lib.rs
+++ b/pmsa003i/src/lib.rs
@@ -13,30 +13,57 @@ pub struct Pmsa003i<I> {
 
 #[derive(Copy, Clone, Debug)]
 pub struct Reading {
-    /// PM1.0 concentration in µg/𝑚3.
-    pub pm1_0_standard: u16,
-    /// PM2.5 concentration in µg/𝑚3.
-    pub pm2_5_standard: u16,
-    /// PM10.0 concentration in µg/𝑚3.
-    pub pm10_0_standard: u16,
+    /// Particulate concentrations in µg/𝑚3.
+    pub concentrations: Concentrations,
 
-    /// PM1.0 concentration in µg/𝑚3, under atmospheric environment.
+    /// Counts of particles of various diameters in 0.1L of air.
+    pub counts: ParticleCounts,
+
+    /// The sensor version field.
+    pub sensor_version: u8,
+}
+
+/// Particulate concentrations in µg/𝑚3.
+///
+/// This is a separate struct from [`ParticleCounts`] so that they can have
+/// separate [`fmt::Display`] implementations.
+#[derive(Copy, Clone, Debug)]
+pub struct Concentrations {
+    /// PM1.0 concentration in µg/𝑚3, under environmental atmospheric
+    /// conditions.
     ///
     /// *Note*: I don't actually know what "under atmospheric environment" means
     /// but it says that in the datasheet. I am guessing this refers to humidity
     /// compensation?
     pub pm1_0: u16,
-    /// PM2.5 concentration in µg/𝑚3, under atmospheric environment.
+    /// PM1.0 concentration in µg/𝑚3, under standard atmospheric conditions.
+    pub pm1_0_standard: u16,
+
+    /// PM2.5 concentration in µg/𝑚3, under environmental atmospheric
+    /// conditions.
     ///
     /// Note: I don't actually know what "under atmospheric environment" means
     /// but it says that in the datasheet...
     pub pm2_5: u16,
-    /// PM10.0 concentration in µg/𝑚3, under atmospheric environment.
+    /// PM2.5 concentration in µg/𝑚3, under standard atmospheric conditions.
+    pub pm2_5_standard: u16,
+
+    /// PM10.0 concentration in µg/𝑚3, under environmental atmospheric
+    /// conditions.
     ///
     /// Note: I don't actually know what "under atmospheric environment" means
     /// but it says that in the datasheet...
     pub pm10_0: u16,
+    /// PM10.0 concentration in µg/𝑚3, under standard atmospheric conditions.
+    pub pm10_0_standard: u16,
+}
 
+/// Counts of particles of various diameters in 0.1L of air.
+///
+/// This is a separate struct from [`Concetrations`] so that they can have
+/// separate [`fmt::Display`] implementations.
+#[derive(Copy, Clone, Debug)]
+pub struct ParticleCounts {
     /// Number of particles with diameter >= 0.3 µm in 0.1L of air.
     pub particles_0_3um: u16,
     /// Number of particles with diameter >= 0.5 µm in 0.1L of air.
@@ -51,26 +78,30 @@ pub struct Reading {
 
 #[derive(Debug)]
 pub enum Error<E> {
+    /// An error occurred while reading from the I²C bus.
     I2c(E),
+    /// The sum of the packet did not match the checksum.
     Checksum { sum: u16, checksum: u16 },
-    NoMagic,
+    /// The packet was missing the magic word.
+    BadMagic(u16),
 }
+
+const MAGIC: u16 = 0x424d;
+const PACKET_LEN: usize = 32;
+const I2C_ADDR: u8 = 0x12;
 
 impl<I, E> Pmsa003i<I>
 where
     I: i2c::Read<Error = E>,
 {
     pub fn read(&mut self) -> Result<Reading, Error<E>> {
-        const MAGIC: u16 = 0x424d;
-        const PACKET_LEN: usize = 32;
-        const I2C_ADDR: u8 = 0x12;
-
         let mut buf = [0; PACKET_LEN];
         self.i2c.read(I2C_ADDR, &mut buf[..]).map_err(Error::I2c)?;
 
-        if u16::from_be_bytes([buf[0], buf[1]]) != MAGIC {
-            // magic isn't real :(
-            return Err(Error::NoMagic);
+        let magic = u16::from_be_bytes([buf[0], buf[1]]);
+        if magic != MAGIC {
+            // you didn't say the magic word!
+            return Err(Error::BadMagic(magic));
         }
 
         // last two bytes are the checksum so dont include them in the checksum.
@@ -90,21 +121,26 @@ where
 
         // now we get to the good stuff:
         let reading = Reading {
-            pm1_0_standard: u16::from_be_bytes([buf[4], buf[5]]),
-            pm2_5_standard: u16::from_be_bytes([buf[6], buf[7]]),
-            pm10_0_standard: u16::from_be_bytes([buf[8], buf[9]]),
+            concentrations: Concentrations {
+                pm1_0_standard: u16::from_be_bytes([buf[4], buf[5]]),
+                pm2_5_standard: u16::from_be_bytes([buf[6], buf[7]]),
+                pm10_0_standard: u16::from_be_bytes([buf[8], buf[9]]),
 
-            pm1_0: u16::from_be_bytes([buf[9], buf[10]]),
-            pm2_5: u16::from_be_bytes([buf[11], buf[12]]),
-            pm10_0: u16::from_be_bytes([buf[13], buf[14]]),
+                pm1_0: u16::from_be_bytes([buf[9], buf[10]]),
+                pm2_5: u16::from_be_bytes([buf[11], buf[12]]),
+                pm10_0: u16::from_be_bytes([buf[13], buf[14]]),
+            },
 
-            particles_0_3um: u16::from_be_bytes([buf[15], buf[16]]),
-            particles_0_5um: u16::from_be_bytes([buf[17], buf[18]]),
-            particles_2_5um: u16::from_be_bytes([buf[19], buf[20]]),
-            particles_5_0um: u16::from_be_bytes([buf[21], buf[22]]),
-            particles_10_0um: u16::from_be_bytes([buf[23], buf[24]]),
+            counts: ParticleCounts {
+                particles_0_3um: u16::from_be_bytes([buf[15], buf[16]]),
+                particles_0_5um: u16::from_be_bytes([buf[17], buf[18]]),
+                particles_2_5um: u16::from_be_bytes([buf[19], buf[20]]),
+                particles_5_0um: u16::from_be_bytes([buf[21], buf[22]]),
+                particles_10_0um: u16::from_be_bytes([buf[23], buf[24]]),
+            },
+
+            sensor_version: buf[25],
         };
-
         // remaining bytes are version, error code (not documented lol), and
         // the checksum, which we already looked at
 
@@ -112,4 +148,101 @@ where
     }
 }
 
-// === impl
+// === impl Error ===
+
+impl<E: fmt::Display> fmt::Display for Error<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Checksum { sum, checksum } => write!(
+                f,
+                "PMSA003I packet checksum did not match (expected {checksum}, got {sum})"
+            ),
+            Self::I2c(err) => write!(f, "PMSA003I I²C error: {err}"),
+            Self::BadMagic(actual) => write!(
+                f,
+                "PMSA003I didn't say the magic word (expected {MAGIC:#x}. got {actual:#x})"
+            ),
+        }
+    }
+}
+
+// === impl Reading ===
+
+impl fmt::Display for Reading {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            concentrations,
+            counts,
+            sensor_version: _,
+        } = self;
+        concentrations.fmt(f)?;
+        f.write_str(if f.alternate() { "\n" } else { "; " })?;
+        counts.fmt(f)?;
+        Ok(())
+    }
+}
+
+// === impl Concentrations ===
+
+impl Concentrations {
+    pub const UNIT: &str = "µg/𝑚3";
+}
+
+impl fmt::Display for Concentrations {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const UNIT: &str = Concentrations::UNIT;
+        let Self {
+            pm1_0,
+            pm1_0_standard,
+            pm2_5,
+            pm2_5_standard,
+            pm10_0,
+            pm10_0_standard,
+        } = self;
+
+        write!(f, "PM 1.0: {pm1_0} {UNIT}")?;
+        if f.alternate() {
+            write!(f, " ({pm1_0_standard} {UNIT} std)")?;
+        }
+
+        write!(f, ", PM 2.5: {pm2_5} {UNIT}")?;
+        if f.alternate() {
+            write!(f, " ({pm2_5_standard} {UNIT} std)")?;
+        }
+
+        write!(f, ", PM 10.0: {pm10_0} {UNIT}")?;
+        if f.alternate() {
+            write!(f, " ({pm10_0_standard} {UNIT} std)")?;
+        }
+
+        Ok(())
+    }
+}
+
+// === impl ParticleCounts ===
+
+impl ParticleCounts {
+    pub const UNIT: &str = "/0.1L";
+}
+
+impl fmt::Display for ParticleCounts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const UNIT: &str = ParticleCounts::UNIT;
+        const UM: &str = "µm";
+        let Self {
+            particles_0_3um,
+            particles_0_5um,
+            particles_2_5um,
+            particles_5_0um,
+            particles_10_0um,
+        } = self;
+        write!(
+            f,
+            "0.3{UM}: {particles_0_3um}{UNIT}, \
+            0.5{UM}: {particles_0_5um}{UNIT}, \
+            2.5{UM}: {particles_2_5um}{UNIT}, \
+            5.0{UM}: {particles_5_0um}{UNIT}, \
+            10.0{UM}: {particles_10_0um}{UNIT}"
+        )
+    }
+}

--- a/pmsa003i/src/lib.rs
+++ b/pmsa003i/src/lib.rs
@@ -250,7 +250,7 @@ impl fmt::Display for Concentrations {
 // === impl ParticleCounts ===
 
 impl ParticleCounts {
-    pub const UNIT: &str = "/0.1L";
+    pub const UNIT: &str = "per 0.1L";
 }
 
 impl fmt::Display for ParticleCounts {
@@ -267,12 +267,13 @@ impl fmt::Display for ParticleCounts {
         } = self;
         write!(
             f,
-            "0.3{UM}: {particles_0_3um}{UNIT}, \
-            0.5{UM}: {particles_0_5um}{UNIT}, \
-            1.0{UM}: {particles_1_0um}{UNIT}, \
-            2.5{UM}: {particles_2_5um}{UNIT}, \
-            5.0{UM}: {particles_5_0um}{UNIT}, \
-            10.0{UM}: {particles_10_0um}{UNIT}"
+            "{UNIT} of air: \
+            >=0.3{UM}: {particles_0_3um}, \
+            >=0.5{UM}: {particles_0_5um}, \
+            >=1.0{UM}: {particles_1_0um}, \
+            >=2.5{UM}: {particles_2_5um}, \
+            >=5.0{UM}: {particles_5_0um}, \
+            >=10.0{UM}: {particles_10_0um}"
         )
     }
 }

--- a/pmsa003i/src/lib.rs
+++ b/pmsa003i/src/lib.rs
@@ -1,0 +1,110 @@
+// stolen from
+// https://github.com/adafruit/Adafruit_PM25AQI/blob/master/Adafruit_PM25AQI.cpp
+// except the bugs, which are my own :)
+// and also the datasheet, which is extremely translated:
+// https://cdn-shop.adafruit.com/product-files/4632/4505_PMSA003I_series_data_manual_English_V2.6.pdf
+use embedded_hal::blocking::i2c;
+
+pub struct Pmsa003i<I> {
+    i2c: I,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Reading {
+    // pm1: f32,
+    // pm2_5: f32,
+    // pm10: f32,
+    // uint16_t framelen;       ///< How long this data chunk is
+    /// PM1.0 concentration in µg/𝑚3.
+    pm1_0_standard: u16,
+    /// PM2.5 concentration in µg/𝑚3.
+    pm2_5_standard: u16,
+    /// PM10.0 concentration in µg/𝑚3.
+    pm10_0_standard: u16,
+
+    /// PM1.0 concentration in µg/𝑚3, under atmospheric environment.
+    ///
+    /// Note: I don't actually know what "under atmospheric environment" means
+    /// but it says that in the datasheet...
+    pm1_0_env: u16,
+    /// PM2.5 concentration in µg/𝑚3, under atmospheric environment.
+    ///
+    /// Note: I don't actually know what "under atmospheric environment" means
+    /// but it says that in the datasheet...
+    pm2_5_env: u16,
+    /// PM10.0 concentration in µg/𝑚3, under atmospheric environment.
+    ///
+    /// Note: I don't actually know what "under atmospheric environment" means
+    /// but it says that in the datasheet...
+    pm10_0_env: u16,
+
+    /// Number of particles with diameter >= 0.3 µm in 0.1L of air.
+    particles_0_3um: u16,
+    /// Number of particles with diameter >= 0.5 µm in 0.1L of air.
+    particles_0_5um: u16,
+    /// Number of particles with diameter >= 2.5 µm in 0.1L of air.
+    particles_2_5um: u16,
+    /// Number of particles with diameter >= 5.0 µm in 0.1L of air.
+    particles_5_0um: u16,
+    /// Number of particles with diameter >= 10.0 µm in 0.1L of air.
+    particles_5_0um: u16,
+}
+
+pub enum Error<E> {
+    I2c(E),
+    Checksum { sum: u16, checksum: u16 },
+    NoMagic,
+}
+
+impl<I, E> Pmsa003i<I>
+where
+    I: i2c::Read<Error = E>,
+{
+    pub fn read(&mut self) -> Result<Reading, Error<E>> {
+        const MAGIC: u16 = 0x424d;
+        const PACKET_LEN: usize = 32;
+        const I2C_ADDR: u8 = 0x12;
+
+        let mut buf = [0; PACKET_LEN];
+        self.i2c.read(I2C_ADDR, &mut buf[..]).map_err(Error::I2c)?;
+
+        if u16::from_be_bytes([buf[0], buf[1]]) != MAGIC {
+            // magic isn't real :(
+            return Err(NoMagic);
+        }
+
+        // last two bytes are the checksum so dont include them in the checksum.
+        let sum = buf
+            .iter()
+            .take(PACKET_LEN - 2)
+            .map(|byte| byte as u16)
+            .sum();
+        let checksum = u16::from_be_bytes([buf[PACKET_LEN - 1], buf[PACKET_LEN]]);
+        if sum != checksum {
+            return Err(Error::Checksum { sum, checksum });
+        }
+
+        // bytes 0 and 1 are the magic, which we already looked at
+        // bytes 2 and 3 are the length field, which i don't get why they send,
+        // because the data sheet also tells us how long the packet is lol
+
+        // now we get to the good stuff:
+        let reading = Reading {
+            pm1_0_standard: u16::from_be_bytes([buf[4], buf[5]]),
+            pm2_5_standard: u16::from_be_bytes([buf[6], buf[7]]),
+            pm10_0_standard: u16::from_be_bytes([buf[8], buf[9]]),
+
+            pm1_0_env: u16::from_be_bytes([buf[9], buf[10]]),
+            pm2_5_env: u16::from_be_bytes([buf[11], buf[12]]),
+            pm10_0_env: u16::from_be_bytes([buf[13], buf[14]]),
+
+            particles_0_3um: u16::from_be_bytes([buf[15], buf[16]]),
+            particles_0_5um: u16::from_be_bytes([buf[17], buf[18]]),
+            particles_2_5um: u16::from_be_bytes([buf[19], buf[20]]),
+            particles_5_0um: u16::from_be_bytes([buf[21], buf[22]]),
+            // remaining bytes are version, error code (not documented lol), and
+            // the checksum
+        };
+        Ok(reading)
+    }
+}

--- a/pmsa003i/src/lib.rs
+++ b/pmsa003i/src/lib.rs
@@ -11,10 +11,6 @@ pub struct Pmsa003i<I> {
 
 #[derive(Copy, Clone, Debug)]
 pub struct Reading {
-    // pm1: f32,
-    // pm2_5: f32,
-    // pm10: f32,
-    // uint16_t framelen;       ///< How long this data chunk is
     /// PM1.0 concentration in µg/𝑚3.
     pm1_0_standard: u16,
     /// PM2.5 concentration in µg/𝑚3.
@@ -47,7 +43,7 @@ pub struct Reading {
     /// Number of particles with diameter >= 5.0 µm in 0.1L of air.
     particles_5_0um: u16,
     /// Number of particles with diameter >= 10.0 µm in 0.1L of air.
-    particles_5_0um: u16,
+    particles_10_0um: u16,
 }
 
 pub enum Error<E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bme680;
 pub mod http;
 pub mod metrics;
 pub mod net;
+pub mod pmsa003i;
 pub mod retry;
 pub mod scd30;
 pub mod sensor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 // If using the `binstart` feature of `esp-idf-sys`, always keep this module
 // imported
 use anyhow::Context;
-use eclss::{actor, bme680::Bme680, http, net, scd30::Scd30, sensor, ws2812};
+use eclss::{actor, bme680::Bme680, http, net, pmsa003i::Pmsa003i, scd30::Scd30, sensor, ws2812};
 use embassy_time::Duration;
 use esp_idf_hal::{
     i2c::{I2cConfig, I2cDriver},
@@ -87,6 +87,12 @@ fn main() -> anyhow::Result<()> {
     exec.spawn_local_collect(sensor_mangler.run::<Scd30>(scd30_rx), &mut tasks)
         .context("failed to spawn SCD30 task")?;
 
+    let _pmsa003i_control = {
+        let (tx, rx) = actor::channel(10);
+        exec.spawn_local_collect(sensor_mangler.run::<Pmsa003i>(rx), &mut tasks)
+            .context("failed to spawn PMSA003I task")?;
+        tx
+    };
     let _bme680_control = {
         let (tx, rx) = actor::channel(10);
         exec.spawn_local_collect(sensor_mangler.run::<Bme680>(rx), &mut tasks)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -21,7 +21,7 @@ pub struct SensorMetrics {
     #[serde(serialize_with = "serialize_metric")]
     pub pm_conc: GaugeFamily<'static, 3, DiameterLabel>,
     #[serde(serialize_with = "serialize_metric")]
-    pub pm_count: GaugeFamily<'static, 5, DiameterLabel>,
+    pub pm_count: GaugeFamily<'static, 6, DiameterLabel>,
     #[serde(serialize_with = "serialize_metric")]
     pub sensor_errors: CounterFamily<'static, MAX_METRICS, SensorLabel>,
 }
@@ -64,7 +64,7 @@ impl SensorMetrics {
             pm_count: MetricBuilder::new("pm_count")
                 .with_help("Particulate matter count per 0.1L of air.")
                 .with_unit("particulates per 0.1L")
-                .build_labeled::<_, DiameterLabel, 5>(),
+                .build_labeled::<_, DiameterLabel, 6>(),
             sensor_errors: MetricBuilder::new("sensor_error_count")
                 .with_help("Count of I2C errors that occurred while talking to a sensor")
                 .build_labeled::<_, SensorLabel, 4>(),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -19,12 +19,20 @@ pub struct SensorMetrics {
     #[serde(serialize_with = "serialize_metric")]
     pub gas_resistance: GaugeFamily<'static, MAX_METRICS, SensorLabel>,
     #[serde(serialize_with = "serialize_metric")]
+    pub pm_conc: GaugeFamily<'static, 3, DiameterLabel>,
+    #[serde(serialize_with = "serialize_metric")]
+    pub pm_count: GaugeFamily<'static, 5, DiameterLabel>,
+    #[serde(serialize_with = "serialize_metric")]
     pub sensor_errors: CounterFamily<'static, MAX_METRICS, SensorLabel>,
 }
 
 #[derive(Debug, Eq, PartialEq, serde::Serialize)]
 #[serde(transparent)]
 pub struct SensorLabel(pub &'static str);
+
+#[derive(Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(transparent)]
+pub struct DiameterLabel(pub &'static str);
 
 impl SensorMetrics {
     pub const fn new() -> Self {
@@ -49,6 +57,14 @@ impl SensorMetrics {
                 .with_help("BME680 VOC sensor resistance, in Ohms.")
                 .with_unit("Ohms")
                 .build_labeled::<_, SensorLabel, 4>(),
+            pm_conc: MetricBuilder::new("pm_concentration_ug_m3")
+                .with_help("Particulate matter concentration in ug/m^3")
+                .with_unit("ug/m^3")
+                .build_labeled::<_, DiameterLabel, 3>(),
+            pm_count: MetricBuilder::new("pm_count")
+                .with_help("Particulate matter count per 0.1L of air.")
+                .with_unit("particulates per 0.1L")
+                .build_labeled::<_, DiameterLabel, 5>(),
             sensor_errors: MetricBuilder::new("sensor_error_count")
                 .with_help("Count of I2C errors that occurred while talking to a sensor")
                 .build_labeled::<_, SensorLabel, 4>(),
@@ -77,6 +93,12 @@ impl fmt::Display for SensorMetrics {
 impl FmtLabels for SensorLabel {
     fn fmt_labels(&self, writer: &mut impl core::fmt::Write) -> core::fmt::Result {
         write!(writer, "sensor=\"{}\"", self.0)
+    }
+}
+
+impl FmtLabels for DiameterLabel {
+    fn fmt_labels(&self, writer: &mut impl core::fmt::Write) -> core::fmt::Result {
+        write!(writer, "diameter=\"{}\",sensor=\"PMSA003I\"", self.0)
     }
 }
 

--- a/src/pmsa003i.rs
+++ b/src/pmsa003i.rs
@@ -1,0 +1,80 @@
+use crate::{
+    metrics::{DiameterLabel, Gauge, SensorMetrics},
+    sensor::Sensor,
+    I2cBus, I2cRef,
+};
+
+pub struct Pmsa003i {
+    sensor: pmsa003i::Pmsa003i<I2cRef<'static>>,
+    pm2_5: &'static Gauge,
+    pm1_0: &'static Gauge,
+    pm10_0: &'static Gauge,
+    particles_0_3um: &'static Gauge,
+    particles_0_5um: &'static Gauge,
+    particles_2_5um: &'static Gauge,
+    particles_5_0um: &'static Gauge,
+    particles_10_0um: &'static Gauge,
+}
+
+const NAME: &'static str = "PMSA003I";
+
+impl Sensor for Pmsa003i {
+    type ControlMessage = ();
+
+    const NAME: &'static str = NAME;
+
+    fn bringup(busman: &'static I2cBus, metrics: &'static SensorMetrics) -> anyhow::Result<Self> {
+        log::info!("connecting to {}", Self::NAME);
+        let i2c = busman.acquire_i2c();
+        Ok(Self {
+            sensor: pmsa003i::Pmsa003i::new(i2c),
+            pm2_5: metrics.pm_conc.register(DiameterLabel("2.5")).unwrap(),
+            pm1_0: metrics.pm_conc.register(DiameterLabel("1.0")).unwrap(),
+            pm10_0: metrics.pm_conc.register(DiameterLabel("10.0")).unwrap(),
+            particles_0_3um: metrics.pm_count.register(DiameterLabel("0.3")).unwrap(),
+            particles_0_5um: metrics.pm_count.register(DiameterLabel("0.5")).unwrap(),
+            particles_2_5um: metrics.pm_count.register(DiameterLabel("2.5")).unwrap(),
+            particles_5_0um: metrics.pm_count.register(DiameterLabel("5.0")).unwrap(),
+            particles_10_0um: metrics.pm_count.register(DiameterLabel("10.0")).unwrap(),
+        })
+    }
+
+    fn poll(&mut self) -> anyhow::Result<()> {
+        let pmsa003i::Reading {
+            concentrations,
+            counts,
+            sensor_version: _,
+        } = self
+            .sensor
+            .read()
+            .map_err(|error| anyhow::anyhow!("error reading from {NAME}: {error:?}"))?;
+
+        log::info!("[{NAME}]: {concentrations:#}");
+        log::info!("[{NAME}]: {counts:#}");
+
+        macro_rules! set_metrics {
+            ($src:ident => $($name:ident),+) => {
+                $(
+                    self.$name.set_value($src.$name.into());
+                )+
+            }
+        }
+        set_metrics!(concentrations => pm1_0, pm2_5, pm10_0);
+        set_metrics!(counts =>
+            particles_0_3um,
+            particles_0_5um,
+            particles_2_5um,
+            particles_5_0um,
+            particles_10_0um
+        );
+        Ok(())
+    }
+
+    fn poll_interval(&self) -> embassy_time::Duration {
+        embassy_time::Duration::from_secs(2)
+    }
+
+    fn handle_control_message(&mut self, _: &Self::ControlMessage) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/src/pmsa003i.rs
+++ b/src/pmsa003i.rs
@@ -11,6 +11,7 @@ pub struct Pmsa003i {
     pm10_0: &'static Gauge,
     particles_0_3um: &'static Gauge,
     particles_0_5um: &'static Gauge,
+    particles_1_0um: &'static Gauge,
     particles_2_5um: &'static Gauge,
     particles_5_0um: &'static Gauge,
     particles_10_0um: &'static Gauge,
@@ -33,6 +34,7 @@ impl Sensor for Pmsa003i {
             pm10_0: metrics.pm_conc.register(DiameterLabel("10.0")).unwrap(),
             particles_0_3um: metrics.pm_count.register(DiameterLabel("0.3")).unwrap(),
             particles_0_5um: metrics.pm_count.register(DiameterLabel("0.5")).unwrap(),
+            particles_1_0um: metrics.pm_count.register(DiameterLabel("1.0")).unwrap(),
             particles_2_5um: metrics.pm_count.register(DiameterLabel("2.5")).unwrap(),
             particles_5_0um: metrics.pm_count.register(DiameterLabel("5.0")).unwrap(),
             particles_10_0um: metrics.pm_count.register(DiameterLabel("10.0")).unwrap(),
@@ -49,8 +51,8 @@ impl Sensor for Pmsa003i {
             .read()
             .map_err(|error| anyhow::anyhow!("error reading from {NAME}: {error:?}"))?;
 
-        log::info!("[{NAME}]: {concentrations:#}");
-        log::info!("[{NAME}]: {counts:#}");
+        log::info!("[{NAME}]: particulate concentrations: {concentrations:#}");
+        log::info!("[{NAME}]: particulates {counts:#}");
 
         macro_rules! set_metrics {
             ($src:ident => $($name:ident),+) => {
@@ -63,6 +65,7 @@ impl Sensor for Pmsa003i {
         set_metrics!(counts =>
             particles_0_3um,
             particles_0_5um,
+            particles_1_0um,
             particles_2_5um,
             particles_5_0um,
             particles_10_0um


### PR DESCRIPTION
This branch adds support from the PMSA003I particulate matter sensor
from Plantower. I couldn't find a crate implementing a driver for the
I2C version of this sensor, although there is one for the UART version,
so I wrote my own driver in a separate crate. This will be published to
crates.io eventually.

This branch adds Prometheus metrics for particulate matter
concentrations and counts from the PMSA003I. It does not currently add
support for exposing particulate matter data in the web UI; I'll add
this in a follow-up branch.